### PR TITLE
fixed bcftools stats qc rule issue with outdated wrapper

### DIFF
--- a/workflow/rules/qc-vcf.smk
+++ b/workflow/rules/qc-vcf.smk
@@ -28,9 +28,8 @@ rule bcftools_stats:
         "../envs/bcftools.yaml"
     group:
         "bcftools-stats"
-    wrapper:
-        "v1.7.0/bio/bcftools/stats"
-
+    shell:
+        "bcftools stats {params} {input.calls} > {output} 2> {log}"
 
 rule bcftools_stats_plot:
     input:


### PR DESCRIPTION
resolves #68 

The problem was that in the snakemake wrapper, {input} was used, while in the qc-vcf.smk rule two inputs are given: calls and done. This meant that bcftools stats was called on the foo.vcf.gz.done file, which is what was outlined in the issue description. I replaced the wrapper with this shell code, as updating the wrapper to a newer version caused the output of bcftools stats to be sent to the log file, due to a change in the wrapper code from:
log = snakemake.log_fmt_shell(stdout=False, stderr=True)

to:
log = snakemake.log_fmt_shell(stdout=True, stderr=True)
(https://snakemake.readthedocs.io/en/v5.32.2/_modules/snakemake/script.html#Snakemake.log_fmt_shell)

Please do look carefully at my shell code, as I am not very experienced with snakemake. I ran into the same issue in my project, and this change fixed it for me.